### PR TITLE
Revert Neoforge changes as Neoforge doesn't exist for 1.19.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ultreon Devices Mod [![CircleCI](https://dl.circleci.com/status-badge/img/gh/Ultreon/devices-mod/tree/1.19.3-development.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/Ultreon/devices-mod/tree/1.19.3-development)
 **Language:** Java  
 **Minecraft Version:** `1.19.3`  
-**Mod Loader:** [NeoForged](https://neoforged.net/) & [Fabric](https://fabricmc.net/)
+**Mod Loader:** [Forge](https://files.minecraftforge.net/) & [Fabric](https://fabricmc.net/)
 
 *Fork of [MrCrayfish's Device Mod](https://github.com/MrCrayfish/MrCrayfishDeviceMod)*
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ pluginManagement {
     repositories {
         maven { url "https://maven.fabricmc.net/" }
         maven { url "https://maven.architectury.dev/" }
-        maven { url "https://maven.neoforged.net/" }
+        maven { url "https://maven.minecraftforge.net/" }
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
This reverts commit 7c2a20ac1c1e49ad2c5ddd69dbafd9163b6794bf.