### PR TITLE
Fix two dedicated-server crashes in UltreonDevicesNeo (1.21.1)

### DIFF
--- a/neoforge/src/main/java/dev/ultreon/devices/neoforge/UltreonDevicesNeo.java
+++ b/neoforge/src/main/java/dev/ultreon/devices/neoforge/UltreonDevicesNeo.java
@@ -91,8 +91,9 @@ public final class UltreonDevicesNeo {
 
         instance.registerApplications();
 
-        // Client side stuff
-        if (!DatagenModLoader.isRunningDataGen()) {
+        // Client side stuff — guard with the client env check so the dedicated
+        // server never touches net.minecraft.client.Minecraft (fixes server crash).
+        if (XinexPlatform.getEnv() == Env.CLIENT && !DatagenModLoader.isRunningDataGen()) {
             LOGGER.info("Registering the reload listener.");
             ((ReloadableResourceManager ) Minecraft.getInstance().getResourceManager()).registerReloadListener(new ClientModEvents.ReloaderListener());
         }

--- a/neoforge/src/main/java/dev/ultreon/devices/neoforge/UltreonDevicesNeo.java
+++ b/neoforge/src/main/java/dev/ultreon/devices/neoforge/UltreonDevicesNeo.java
@@ -77,7 +77,9 @@ public final class UltreonDevicesNeo {
         // Common side stuff
         LOGGER.info("Initializing registration handler and mod config.");
         RegistrationHandler.register();
-        container.registerConfig(ModConfig.Type.CLIENT, DeviceConfig.CONFIG);
+        // COMMON (not CLIENT) so the config loads on a dedicated server too — devices:sync_config
+        // reads it on player join and would otherwise fail to encode ("Cannot get config value before config is loaded").
+        container.registerConfig(ModConfig.Type.COMMON, DeviceConfig.CONFIG);
 
         LOGGER.info("Registering common setup handler, and load complete handler.");
         if (XinexPlatform.getEnv() == Env.CLIENT) {


### PR DESCRIPTION
`UltreonDevicesNeo`'s constructor has two issues that make the 1.21.1 build
(`0.9.1`) unusable on a **dedicated server**. Both are already handled in the
newer MC 26.x `NeoForgeDevicesMod`; this backports them to `versions/1.21.1`.

### 1. Client-only class loaded on the dedicated server (crash on load)
```
java.lang.RuntimeException: Attempted to load class net/minecraft/client/Minecraft for invalid dist DEDICATED_SERVER
    at dev.ultreon.devices.neoforge.UltreonDevicesNeo.<init>(UltreonDevicesNeo.java:97)
```
The `// Client side stuff` block calls `Minecraft.getInstance()` guarded only by
`!DatagenModLoader.isRunningDataGen()`. Fix: also guard with
`XinexPlatform.getEnv() == Env.CLIENT` (the pattern used just above for `doClientInit()`).

### 2. Config registered as CLIENT → `sync_config` fails to encode (crash on join)
After #1 is fixed, the server starts, but players are disconnected on join:
```
io.netty.handler.codec.EncoderException: Failed to encode packet 'clientbound/minecraft:custom_payload'
Caused by: Failed encoding custom payload devices:sync_config:
    java.lang.IllegalStateException: Cannot get config value before config is loaded.
```
The config is registered as `ModConfig.Type.CLIENT`, which isn't loaded on a
dedicated server, so `devices:sync_config` can't read it. Fix: register it as
`ModConfig.Type.COMMON` (as 26.x does).

### Testing
Built against 1.21.1 / NeoForge 21.1 and deployed to a live dedicated server
(itzg). With both fixes: the server boots cleanly, `devices-common.toml` is
written server-side, and vanilla 0.9.1 clients join without the `custom_payload`
disconnect. Resolves #131.