### PR TITLE
Fix debug atlas dump crash outside game directory

### DIFF
--- a/common/src/main/java/dev/ultreon/devices/ClientModEvents.java
+++ b/common/src/main/java/dev/ultreon/devices/ClientModEvents.java
@@ -5,6 +5,8 @@ import dev.ultreon.devices.block.entity.renderer.*;
 import dev.ultreon.devices.client.entity.renderer.SeatEntityRenderer;
 import dev.ultreon.devices.core.Laptop;
 import dev.ultreon.devices.debug.DebugFlags;
+import dev.ultreon.devices.debug.DebugUtils;
+import dev.ultreon.devices.debug.DumpType;
 import dev.ultreon.devices.init.DeviceBlockEntities;
 import dev.ultreon.devices.init.DeviceEntities;
 import dev.ultreon.devices.object.AppInfo;
@@ -174,8 +176,9 @@ public class ClientModEvents {
 
                 if (DebugFlags.DUMP_APP_ICON_ATLAS) {
                     try {
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
+                        DebugUtils.dump(DumpType.ATLAS, OmnixerioDevicesCommon.id("textures/atlas/app_icons.png"), stream -> ImageIO.write(atlas, "png", stream));
+                    } catch (IOException e) {
+                        OmnixerioDevicesCommon.LOGGER.warn("Failed to dump app icon atlas debug texture.", e);
                     }
                 }
 

--- a/common/src/main/java/dev/ultreon/devices/debug/DebugUtils.java
+++ b/common/src/main/java/dev/ultreon/devices/debug/DebugUtils.java
@@ -1,21 +1,24 @@
 package dev.ultreon.devices.debug;
 
+import dev.ultreon.devices.platform.Services;
 import net.minecraft.resources.Identifier;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class DebugUtils {
     public static void dump(DumpType type, Identifier resource, DumpWriter dumpFunc) throws IOException {
-        File namespaceFile = new File("debug/dump/" + type.name().toLowerCase(), resource.getNamespace());
-        File outputFile = new File(namespaceFile, resource.getPath());
-        File outputDir = outputFile.getParentFile();
-        if (!outputDir.exists() && !outputDir.mkdirs()) {
-            throw new IOException("Creating output directory failed for: " + outputFile.getPath());
-        }
-        try (FileOutputStream stream = new FileOutputStream(outputFile)) {
+        Path outputFile = Services.PLATFORM.getGameDir()
+                .resolve("debug")
+                .resolve("dump")
+                .resolve(type.name().toLowerCase())
+                .resolve(resource.getNamespace())
+                .resolve(resource.getPath());
+
+        Files.createDirectories(outputFile.getParent());
+        try (OutputStream stream = Files.newOutputStream(outputFile)) {
             dumpFunc.dump(stream);
         }
     }

--- a/common/src/main/java/dev/ultreon/devices/platform/services/IPlatformHelper.java
+++ b/common/src/main/java/dev/ultreon/devices/platform/services/IPlatformHelper.java
@@ -86,4 +86,6 @@ public interface IPlatformHelper {
     String getModVersion();
 
     Path getConfigDir();
+
+    Path getGameDir();
 }

--- a/fabric/src/main/java/dev/ultreon/devices/fabric/platform/FabricPlatformHelper.java
+++ b/fabric/src/main/java/dev/ultreon/devices/fabric/platform/FabricPlatformHelper.java
@@ -202,4 +202,9 @@ public class FabricPlatformHelper implements IPlatformHelper {
     public Path getConfigDir() {
         return FabricLoader.getInstance().getConfigDir();
     }
+
+    @Override
+    public Path getGameDir() {
+        return FabricLoader.getInstance().getGameDir();
+    }
 }

--- a/neoforge/src/main/java/dev/ultreon/devices/neoforge/platform/NeoForgePlatformHelper.java
+++ b/neoforge/src/main/java/dev/ultreon/devices/neoforge/platform/NeoForgePlatformHelper.java
@@ -193,6 +193,11 @@ public class NeoForgePlatformHelper implements IPlatformHelper {
         return FMLPaths.CONFIGDIR.get();
     }
 
+    @Override
+    public Path getGameDir() {
+        return FMLPaths.GAMEDIR.get();
+    }
+
     @SubscribeEvent
     public static void registerNetwork(RegisterPayloadHandlersEvent event) {
         PayloadRegistrar registrar = event.registrar(IPlatformHelper.NETWORK_VERSION);


### PR DESCRIPTION
## Summary
- write debug dump output under the loader-provided game directory instead of the JVM working directory
- make app icon atlas debug dump failures non-fatal so optional diagnostics cannot break mod loading
- add a cross-loader game directory accessor for Fabric and NeoForge

## Root cause
Devices wrote debug dumps using relative paths like `debug/dump/...`, which resolve against `user.dir`. Some launchers set `user.dir` outside the Minecraft game directory, so the optional app icon atlas dump could fail during startup and crash mod loading.

## Validation
- `./gradlew :common:compileJava :fabric:compileJava :neoforge:compileJava`
- `./gradlew :fabric:build :neoforge:build`